### PR TITLE
removed reference to removed test.js

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -28,9 +28,6 @@
     <clobbers target="window.plugins.toast" />
   </js-module>
 
-  <js-module src="test/tests.js" name="tests">
-  </js-module>
-
   <!-- ios -->
   <platform name="ios">
 


### PR DESCRIPTION
Build fails with 2.6.1 due to missing file, removed reference to this file for cordova